### PR TITLE
Deep/visa 17 intermediate changes

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
-      <version>3.10.6.Final</version>
+      <version>3.10.6.Final-patch1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -314,8 +314,11 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         //deviation of [7,8,9] is 1/3, stddev is sqrt(1/3), approximately 0.8165
         Assert.assertEquals(0.8165, Double.parseDouble(Iterables.getOnlyElement(row.getDimension("stddev"))), 0.0001);
 
-        //append is not supported
-        Assert.assertEquals(Collections.emptyList(), row.getDimension("append"));
+        // we do not support json-path append function for ORC format (see https://github.com/apache/druid/pull/11722)
+        Exception exception = Assert.assertThrows(UnsupportedOperationException.class, () -> {
+          row.getDimension("append");
+        });
+        Assert.assertEquals("Unused", exception.getMessage());
       }
       Assert.assertEquals(1, actualRowCount);
     }

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -397,7 +397,7 @@ name: JsonPath
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.3.0
+version: 2.9.0
 libraries:
   - com.jayway.jsonpath: json-path
 
@@ -507,7 +507,7 @@ name: Apache Commons Codec
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.16.0
+version: 1.16.1
 libraries:
   - commons-codec: commons-codec
 notices:
@@ -632,7 +632,7 @@ name: Apache Commons Compress
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.24.0
+version: 1.26.0
 libraries:
   - org.apache.commons: commons-compress
 notices:
@@ -2065,7 +2065,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.53.v20231009
+version: 9.4.54.v20240208
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1249,7 +1249,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.100.Final
+version: 4.1.108.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec
@@ -1988,7 +1988,7 @@ name: Apache Zookeeper
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.8.3
+version: 3.8.4
 libraries:
   - org.apache.zookeeper: zookeeper
   - org.apache.zookeeper: zookeeper-jute
@@ -4436,7 +4436,7 @@ name: Netty
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 2.0.61.Final
+version: 2.0.65.Final
 libraries:
   - io.netty: netty-tcnative-boringssl-static
   - io.netty: netty-tcnative-classes

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -21,7 +21,7 @@
   <!-- False positives -->
   <suppress>
     <notes><![CDATA[
-     file name: json-path-2.3.0.jar jackson-core-2.12.7.jar
+     file name: json-path-2.9.0.jar jackson-core-2.12.7.jar
      ]]></notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-35116</cve>

--- a/pom.xml
+++ b/pom.xml
@@ -1327,6 +1327,11 @@
               <artifactId>joni</artifactId>
               <version>2.1.34</version>
           </dependency>
+          <dependency>
+              <groupId>org.codehaus.janino</groupId>
+              <artifactId>janino</artifactId>
+              <version>3.1.10</version>
+          </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final-patch1</netty3.version>
-        <netty4.version>4.1.100.Final</netty4.version>
+        <netty4.version>4.1.108.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
         <protobuf.version>3.24.0</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
@@ -124,7 +124,7 @@
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
-        <zookeeper.version>3.8.3</zookeeper.version>
+        <zookeeper.version>3.8.4</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
         <com.google.apis.client.version>2.2.0</com.google.apis.client.version>
         <com.google.http.client.apis.version>1.42.3</com.google.http.client.apis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.version>9.4.54.v20240208</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.12.7.20221012</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
@@ -285,7 +285,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.16.0</version>
+                <version>1.16.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -562,7 +562,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <version>1.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.tukaani</groupId>
@@ -923,7 +923,7 @@
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.3.0</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>net.thisptr</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -81,6 +81,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+    <!-- commons-codec is an optional dependency of commons-compress starting with 1.26.0 which we require at runtime -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>


### PR DESCRIPTION
Backported fixes:
https://github.com/apache/druid/pull/16267
https://github.com/apache/druid/pull/16009
https://github.com/apache/druid/pull/15772
https://github.com/apache/druid/pull/16000

https://github.com/apache/druid/pull/16504 was omitted because of conflicts complexity so only problematic janino-3.1.9.jar was upgraded 

Netty 3.10.6.Final upgraded to 3.10.6.Final-patch1