### PR TITLE
auto index disabling for virtual columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -777,4 +777,9 @@ public class QueryContext
   {
     return getBoolean(QueryContexts.REALTIME_SEGMENTS_ONLY, QueryContexts.DEFAULT_REALTIME_SEGMENTS_ONLY);
   }
+
+  public int getMaxVirtualColumnsForBitmapIndexing()
+  {
+    return getInt(QueryContexts.CTX_MAX_VIRTUAL_COLUMNS_FOR_BITMAP, QueryContexts.DEFAULT_MAX_VIRTUAL_COLUMNS_FOR_BITMAP);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -142,6 +142,8 @@ public class QueryContexts
   public static final boolean DEFAULT_REALTIME_SEGMENTS_ONLY = false;
 
   public static final String CTX_PREPLANNED = "prePlanned";
+  public static final String CTX_MAX_VIRTUAL_COLUMNS_FOR_BITMAP = "maxVirtualColumnsForBitmapIndexing";
+
   public static final boolean DEFAULT_PREPLANNED = true;
 
   // Defaults
@@ -177,6 +179,7 @@ public class QueryContexts
   public static final boolean DEFAULT_USE_NESTED_FOR_UNKNOWN_TYPE_IN_SUBQUERY = false;
   public static final boolean DEFAULT_EXTENDED_FILTERED_SUM_REWRITE_ENABLED = true;
   public static final boolean DEFAULT_CTX_FULL_REPORT = false;
+  public static final int DEFAULT_MAX_VIRTUAL_COLUMNS_FOR_BITMAP = Integer.MAX_VALUE;
 
 
   @SuppressWarnings("unused") // Used by Jackson serialization

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumnBitmapDisablingIndexSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumnBitmapDisablingIndexSelector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.query.filter.ColumnIndexSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ColumnIndexSupplier;
+import org.apache.druid.segment.column.SelectableColumn;
+import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
+import org.apache.druid.segment.serde.NoIndexesColumnIndexSupplier;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public final class VirtualColumnBitmapDisablingIndexSelector implements ColumnIndexSelector
+{
+  private static final ColumnIndexSupplier NO_INDEXES = NoIndexesColumnIndexSupplier.getInstance();
+  private final ColumnIndexSelector delegate;
+  private final VirtualColumns virtualColumns;
+
+
+  public VirtualColumnBitmapDisablingIndexSelector(
+      final ColumnIndexSelector delegate,
+      final VirtualColumns virtualColumns
+  )
+  {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.virtualColumns = Objects.requireNonNull(virtualColumns, "virtualColumns");
+  }
+
+  @Override
+  public int getNumRows()
+  {
+    return delegate.getNumRows();
+  }
+
+  @Override
+  public BitmapFactory getBitmapFactory()
+  {
+    return delegate.getBitmapFactory();
+  }
+
+  @Override
+  @Nullable
+  public ColumnHolder getColumnHolder(final String columnName)
+  {
+    final ColumnHolder holder = delegate.getColumnHolder(columnName);
+    if (holder == null || !isVirtual(columnName)) {
+      return holder;
+    }
+
+    // force no indexes even if callers go via getColumnHolder().
+    return new ColumnHolder()
+    {
+      @Override
+      public ColumnCapabilities getCapabilities()
+      {
+        return holder.getCapabilities();
+      }
+
+      @Override
+      public int getLength()
+      {
+        return holder.getLength();
+      }
+
+      @Override
+      public SelectableColumn getColumn()
+      {
+        return holder.getColumn();
+      }
+
+      @Override
+      public ColumnIndexSupplier getIndexSupplier()
+      {
+        return NO_INDEXES;
+      }
+
+      @Override
+      public SettableColumnValueSelector makeNewSettableColumnValueSelector()
+      {
+        return holder.makeNewSettableColumnValueSelector();
+      }
+    };
+  }
+
+  @Override
+  @Nullable
+  public ColumnIndexSupplier getIndexSupplier(final String column)
+  {
+    if (column.isEmpty()) {
+      return null;
+    }
+
+    // Only disable indexes for virtual columns
+    if (isVirtual(column)) {
+      return NO_INDEXES;
+    }
+    return delegate.getIndexSupplier(column);
+  }
+
+
+  private boolean isVirtual(final String columnName)
+  {
+    return virtualColumns.getVirtualColumn(columnName) != null;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterBundleVCBitmapIndexDisablingTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterBundleVCBitmapIndexDisablingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.filter;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.DefaultBitmapResultFactory;
+import org.apache.druid.query.filter.ColumnIndexSelector;
+import org.apache.druid.query.filter.EqualityFilter;
+import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.FilterBundle;
+import org.apache.druid.segment.ColumnCache;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.VirtualColumnBitmapDisablingIndexSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class FilterBundleVCBitmapIndexDisablingTest extends InitializedNullHandlingTest
+{
+
+  @Test
+  public void testVCBitmapIndexEnabled()
+  {
+    final VirtualColumns virtualColumns = VirtualColumns.create(ImmutableList.of(
+        new ExpressionVirtualColumn("v1",
+                                    "countryName", ColumnType.STRING,
+                                    ExprMacroTable.nil()
+        )
+    ));
+    final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
+    BitmapFactory bitmapFactory = index.getBitmapFactoryForDimensions();
+
+    try (Closer closer = Closer.create()) {
+      ColumnCache columnCache = new ColumnCache(index, virtualColumns, closer);
+      VirtualColumnBitmapDisablingIndexSelector selector = new VirtualColumnBitmapDisablingIndexSelector(columnCache,
+                                                                                                         virtualColumns
+      );
+
+      final FilterBundle filterBundleIndexEnabled = makeFilterBundle(new AndFilter(ImmutableList.of(
+          new EqualityFilter("v1", ColumnType.STRING, "United States", null),
+          new EqualityFilter("countryName",
+                             ColumnType.STRING,
+                             "United States",
+                             null
+          )
+      )), columnCache, bitmapFactory);
+
+      final FilterBundle filterBundleIndexDisabled = makeFilterBundle(new AndFilter(ImmutableList.of(
+          new EqualityFilter("v1", ColumnType.STRING, "United States", null),
+          new EqualityFilter("countryName",
+                             ColumnType.STRING,
+                             "United States",
+                             null
+          )
+      )), selector, bitmapFactory);
+
+      Assert.assertEquals(2, filterBundleIndexEnabled.getIndex().getIndexInfo().getIndexes().size());
+      Assert.assertEquals("v1 = United States", filterBundleIndexEnabled.getIndex().getIndexInfo().getIndexes().get(0).getFilter());
+      Assert.assertEquals("countryName = United States", filterBundleIndexEnabled.getIndex().getIndexInfo().getIndexes().get(1).getFilter());
+
+      Assert.assertNull(filterBundleIndexDisabled.getIndex().getIndexInfo().getIndexes());
+      Assert.assertEquals("countryName = United States", filterBundleIndexDisabled.getIndex().getIndexInfo().getFilter());
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  protected FilterBundle makeFilterBundle(
+      final Filter filter,
+      ColumnIndexSelector selector,
+      BitmapFactory bitmapFactory
+  )
+  {
+    return new FilterBundle.Builder(filter, selector, false).build(new DefaultBitmapResultFactory(bitmapFactory),
+                                                                   selector.getNumRows(),
+                                                                   selector.getNumRows(),
+                                                                   false
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/filter/VirtualColumnBitmapDisablingIndexSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/VirtualColumnBitmapDisablingIndexSelectorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.filter;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.filter.ColumnIndexSelector;
+import org.apache.druid.segment.ColumnCache;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.VirtualColumnBitmapDisablingIndexSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.serde.NoIndexesColumnIndexSupplier;
+import org.apache.druid.segment.serde.StringUtf8ColumnIndexSupplier;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class VirtualColumnBitmapDisablingIndexSelectorTest extends InitializedNullHandlingTest
+{
+  @Test
+  public void testNative_disablesIndexSupplierForVirtualColumnsOnly() throws Exception
+  {
+    final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
+
+    final VirtualColumns virtualColumns = VirtualColumns.create(ImmutableList.of(new ExpressionVirtualColumn(
+                                                                                     "v0",
+                                                                                     "countryName",
+                                                                                     ColumnType.STRING,
+                                                                                     ExprMacroTable.nil()
+                                                                                 ),
+                                                                                 new ExpressionVirtualColumn("v1",
+                                                                                                             "cityName",
+                                                                                                             ColumnType.STRING,
+                                                                                                             ExprMacroTable.nil()
+                                                                                 )
+    ));
+
+    try (Closer closer = Closer.create()) {
+      final ColumnCache columnCache = new ColumnCache(index, virtualColumns, closer);
+
+      assertEquals(StringUtf8ColumnIndexSupplier.class,
+                   Objects.requireNonNull(columnCache.getIndexSupplier("v0")).getClass()
+      );
+      assertEquals(StringUtf8ColumnIndexSupplier.class,
+                   Objects.requireNonNull(columnCache.getIndexSupplier("v1")).getClass()
+      );
+
+      final ColumnIndexSelector vcIndexDisabled = new VirtualColumnBitmapDisablingIndexSelector(columnCache,
+                                                                                                virtualColumns
+      );
+
+      assertSame(NoIndexesColumnIndexSupplier.getInstance(), vcIndexDisabled.getIndexSupplier("v0"));
+      assertSame(NoIndexesColumnIndexSupplier.getInstance(), vcIndexDisabled.getIndexSupplier("v1"));
+
+      assertEquals(
+          StringUtf8ColumnIndexSupplier.class,
+          Objects.requireNonNull(vcIndexDisabled.getIndexSupplier("countryName")).getClass()
+      );
+      assertEquals(
+          StringUtf8ColumnIndexSupplier.class,
+          Objects.requireNonNull(vcIndexDisabled.getIndexSupplier("cityName")).getClass()
+      );
+    }
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/VcBitmapIndexDisablingSqlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/VcBitmapIndexDisablingSqlTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.segment.ColumnCache;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.VirtualColumnBitmapDisablingIndexSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.serde.NoIndexesColumnIndexSupplier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+public class VcBitmapIndexDisablingSqlTest extends BaseCalciteQueryTest
+{
+  @Test
+  public void testSqlPlannedQueryVirtualColumnsHaveNoIndexSupplierWhenDisabled()
+  {
+    final Map<String, Object> ctx = ImmutableMap.<String, Object>builder()
+                                                .putAll(QUERY_CONTEXT_DEFAULT)
+                                                .put(
+                                                    QueryContexts.CTX_MAX_VIRTUAL_COLUMNS_FOR_BITMAP,
+                                                    0
+                                                )
+                                                .build();
+
+    final String sql = "SELECT countryName + '' AS v0 FROM wikipedia LIMIT 1";
+
+    testBuilder()
+        .queryContext(ctx)
+        .sql(sql)
+        .expectedResults((s, queryResults) -> {
+          final List<Query<?>> planned = queryResults.recordedQueries;
+          Assertions.assertFalse(planned.isEmpty());
+
+          final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
+
+          for (Query<?> q : planned) {
+            final VirtualColumns vcs = q.getVirtualColumns();
+            if (vcs == null || vcs.isEmpty()) {
+              continue;
+            }
+
+            try (var closer = Closer.create()) {
+              final var columnCache = new
+                  ColumnCache(index, vcs, closer);
+              final var selector = new VirtualColumnBitmapDisablingIndexSelector(columnCache, vcs);
+
+              Assertions.assertSame(NoIndexesColumnIndexSupplier.getInstance(), selector.getIndexSupplier("v0"));
+              return;
+            }
+            catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+
+          fail("SQL did not plan any query with virtualColumns");
+        })
+        .run();
+  }
+}


### PR DESCRIPTION
Tested with native/sql/msq this QueryableIndexCursorHolder is used in all 3 