### PR TITLE
Bumped version of following libs: (#16) (#19)

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -222,11 +222,31 @@ notice: |
 name: Jackson
 license_category: binary
 module: java-core
+module: extensions/druid-parquet-extensions
 license_name: Apache License version 2.0
-version: 2.12.7
+version: 2.18.4.1
+libraries:
+  - com.fasterxml.jackson.core: jackson-core
+
+---
+
+name: Jackson
+license_category: binary
+module: extensions/druid-parquet-extensions
+license_name: Apache License version 2.0
+version: 2.18.4.1
+libraries:
+  - com.fasterxml.jackson.core: jackson-core
+
+---
+
+name: Jackson
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+version: 2.18.4
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
-  - com.fasterxml.jackson.core: jackson-core
   - com.fasterxml.jackson.dataformat: jackson-dataformat-cbor
   - com.fasterxml.jackson.dataformat: jackson-dataformat-smile
   - com.fasterxml.jackson.dataformat: jackson-dataformat-xml
@@ -266,7 +286,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7.1
+version: 2.18.4
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -364,6 +384,16 @@ license_name: Apache License version 2.0
 version: 1.3
 libraries:
   - com.google.j2objc: j2objc-annotations
+
+---
+
+name: jaxb-api
+license_category: binary
+module: core
+license_name: CDDL 1.1
+version: 2.2.12
+libraries:
+  - javax.xml.bind: jaxb-api
 
 ---
 
@@ -489,7 +519,7 @@ name: Apache Commons BeanUtils
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.9.4
+version: 1.11.0
 libraries:
   - commons-beanutils: commons-beanutils
 notices:
@@ -542,7 +572,7 @@ name: Apache Commons IO
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.17.0
+version: 2.20.0
 libraries:
   - commons-io: commons-io
 notices:
@@ -2100,7 +2130,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.57.v20241219
+version: 9.4.58.v20250814
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation
@@ -2846,7 +2876,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.12.7
+version: 2.18.4
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -232,16 +232,6 @@ libraries:
 
 name: Jackson
 license_category: binary
-module: extensions/druid-parquet-extensions
-license_name: Apache License version 2.0
-version: 2.18.4.1
-libraries:
-  - com.fasterxml.jackson.core: jackson-core
-
----
-
-name: Jackson
-license_category: binary
 module: java-core
 license_name: Apache License version 2.0
 version: 2.18.4

--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,10 @@
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>5.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.57.v20241219</jetty.version>
+        <jetty.version>9.4.58.v20250814</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.12.7.20221012</jackson.version>
+        <jackson.core.version>2.18.4.1</jackson.core.version>
+        <jackson.version>2.18.4</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.22.1</log4j.version>
         <mysql.version>8.2.0</mysql.version>
@@ -322,7 +323,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.17.0</version>
+                <version>2.20.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
@@ -620,7 +621,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.core.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -966,7 +967,7 @@
             <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <!-- override the transitive dependency from com.opencsv:opensv:4.6 to version 1.9.3 to address CVE-2014-0114 -->
-                <version>1.9.4</version>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>

--- a/processing/src/main/java/org/apache/druid/jackson/JodaStuff.java
+++ b/processing/src/main/java/org/apache/druid/jackson/JodaStuff.java
@@ -117,7 +117,8 @@ class JodaStuff
         // make sure to preserve time zone information when parsing timestamps
         return DateTimes.ISO_DATE_OR_TIME_WITH_OFFSET.parse(str);
       }
-      throw ctxt.mappingException(getValueClass());
+      ctxt.reportWrongTokenException(handledType(), JsonToken.VALUE_NUMBER_INT, "expected int or string token");
+      return null; // unreachable ... required for compiler, but ctxt.reportWrongTokenException always throws
     }
   }
 }


### PR DESCRIPTION
Jackson: upgraded from 2.12.7.20221012 to 2.18.4
Jetty: upgraded from 9.4.56.v20240826 to 9.4.58.v20250814
   Note: One indirect vulnerability (CVE-2024-6763, severity LOW – 3.7) still remains
Commons BeanUtils: upgraded from 1.9.4 to 1.11.0
Commons IO: upgraded from 2.14.0 to 2.20.0